### PR TITLE
feat: Add support for AUTO_CREATE_PR automation mode

### DIFF
--- a/src/jules_agent_sdk/models.py
+++ b/src/jules_agent_sdk/models.py
@@ -200,6 +200,7 @@ class Session:
     name: str = ""
     id: str = ""
     title: str = ""
+    automation_mode: Optional[str] = None
     require_plan_approval: bool = False
     create_time: str = ""
     update_time: str = ""
@@ -228,6 +229,7 @@ class Session:
             prompt=data.get("prompt", ""),
             source_context=source_context,
             title=data.get("title", ""),
+            automation_mode=data.get("automationMode"),
             require_plan_approval=data.get("requirePlanApproval", False),
             create_time=data.get("createTime", ""),
             update_time=data.get("updateTime", ""),
@@ -246,6 +248,8 @@ class Session:
             result["name"] = self.name
         if self.title:
             result["title"] = self.title
+        if self.automation_mode:
+            result["automationMode"] = self.automation_mode
         if self.require_plan_approval:
             result["requirePlanApproval"] = self.require_plan_approval
         if self.outputs:

--- a/src/jules_agent_sdk/sessions.py
+++ b/src/jules_agent_sdk/sessions.py
@@ -30,6 +30,7 @@ class SessionsAPI:
         starting_branch: Optional[str] = None,
         title: Optional[str] = None,
         require_plan_approval: bool = False,
+        automation_mode: Optional[str] = None,
     ) -> Session:
         """Create a new session.
 
@@ -39,6 +40,7 @@ class SessionsAPI:
             starting_branch: Optional starting branch for GitHub repos
             title: Optional session title
             require_plan_approval: If True, plans require explicit approval
+            automation_mode: Optional automation mode (e.g., "AUTO_CREATE_PR")
 
         Returns:
             Created Session object
@@ -65,6 +67,9 @@ class SessionsAPI:
 
         if require_plan_approval:
             data["requirePlanApproval"] = require_plan_approval
+
+        if automation_mode:
+            data["automationMode"] = automation_mode
 
         response = self.client.post("sessions", json=data)
         return Session.from_dict(response)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,6 +48,34 @@ class TestJulesClient:
         mock_request.assert_called_once()
 
     @patch("jules_agent_sdk.base.BaseClient._request")
+    def test_sessions_create_with_automation_mode(self, mock_request):
+        """Test session creation with automation mode."""
+        mock_request.return_value = {
+            "name": "sessions/test456",
+            "id": "test456",
+            "prompt": "Auto PR feature",
+            "sourceContext": {"source": "sources/repo2"},
+            "state": "QUEUED",
+            "automationMode": "AUTO_CREATE_PR",
+        }
+
+        client = JulesClient(api_key="test-api-key")
+        session = client.sessions.create(
+            prompt="Auto PR feature",
+            source="sources/repo2",
+            automation_mode="AUTO_CREATE_PR",
+        )
+
+        assert session.id == "test456"
+        assert session.automation_mode == "AUTO_CREATE_PR"
+
+        # Verify that automationMode was included in the request data
+        mock_request.assert_called_once()
+        _name, _args, kwargs = mock_request.mock_calls[0]
+        assert "json" in kwargs
+        assert kwargs["json"]["automationMode"] == "AUTO_CREATE_PR"
+
+    @patch("jules_agent_sdk.base.BaseClient._request")
     def test_sessions_get(self, mock_request):
         """Test getting a session."""
         mock_request.return_value = {


### PR DESCRIPTION
This change updates the Jules Agent SDK to support the new AUTO_CREATE_PR automation mode. It adds an optional automation_mode parameter to the sessions.create method, allowing users to create sessions that automatically generate a pull request upon completion.